### PR TITLE
Fixes and updates

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -47,8 +47,8 @@
           cp -r . $out
           mkdir $out/bin
           cat > $out/bin/${self.packages.${system}.default.pname} <<EOL
-            #!/usr/bin/env bash
-            ${playdate-sdk-pkg}/bin/PlaydateSimulator $out/${game-name}
+          #!/usr/bin/env bash
+          ${playdate-sdk-pkg}/bin/PlaydateSimulator $out/${game-name}
           EOL
           chmod 555 $out/bin/${self.packages.${system}.default.pname}
           cd $out

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -7,9 +7,10 @@
       pkgs = nixpkgs.legacyPackages.${system};
       stdenv = pkgs.stdenv;
       playdate-sdk-pkg = playdate-sdk.packages.${system}.default;
+      game-name = "hello_world.pdx";
   in
   {
-    devShells.${system}.default = with stdenv; pkgs.mkShell {
+    devShells.${system}.default = pkgs.mkShell {
       packages = [playdate-sdk-pkg];
       shellHook = ''
       export PLAYDATE_SDK_PATH=`pwd`/.PlaydateSDK
@@ -17,7 +18,7 @@
     };
     packages.${system} = {
       default = self.packages.${system}.playdate-example;
-      playdate-example = with stdenv; mkDerivation rec {
+      playdate-example = with stdenv; mkDerivation {
         pname = "playdate-example";
         version = "1.0.0";
         src = with pkgs.lib.fileset; toSource {
@@ -28,7 +29,7 @@
             ./Source
           ];
         };
-        outName = "hello_world.pdx";
+        outName = game-name;
         nativeBuildInputs = [playdate-sdk-pkg pkgs.gcc-arm-embedded pkgs.cmake];
         buildInputs = [ playdate-sdk-pkg ];
         cmakeFlags = ["-DPLAYDATE_SDK_PATH=`pwd`/.PlaydateSDK"];
@@ -47,11 +48,11 @@
           mkdir $out/bin
           cat > $out/bin/${self.packages.${system}.default.pname} <<EOL
             #!/usr/bin/env bash
-            ${playdate-sdk-pkg}/bin/PlaydateSimulator $out/hello_world.pdx
+            ${playdate-sdk-pkg}/bin/PlaydateSimulator $out/${game-name}
           EOL
           chmod 555 $out/bin/${self.packages.${system}.default.pname}
           cd $out
-          zip -r playdat-example.pdx.zip playdate-example.pdx
+          ${pkgs.zip}/bin/zip -r ${game-name}.zip ${game-name}
           runHook postInstall
         '';
       };

--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
-        "path": "/nix/store/qzjidyx3fip413vg7by6ibl22lwizc68-source",
-        "type": "path"
+        "lastModified": 1759570798,
+        "narHash": "sha256-kbkzsUKYzKhuvMOuxt/aTwWU2mnrwoY964yN3Y4dE98=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0d4f673a88f8405ae14484e6a1ea870e0ba4ca26",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/playdate-sdk.nix
+++ b/playdate-sdk.nix
@@ -18,7 +18,7 @@
     cairo
     gdk-pixbuf
     glib
-    webkitgtk
+    webkitgtk_4_1
     xorg.libX11
     stdenv.cc.cc.lib
     libxkbcommon
@@ -35,10 +35,10 @@
 in
   stdenv.mkDerivation rec {
     pname = "playdate-sdk";
-    version = "2.7.6";
+    version = "3.0.0";
     src = pkgs.fetchurl {
       url = "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${version}.tar.gz";
-      sha256 = "sha256-PjirdoWe4oC73lWusekV4RJTnUHrRxzQPMz3DdQ9e0Y=";
+      sha256 = "sha256-1VDoFt9hsc/bT9ZAzliTUioY5BEr+18Dut0P6FzF5+0=";
     };
 
     buildInputs = pdcInputs;

--- a/playdate-sdk.nix
+++ b/playdate-sdk.nix
@@ -35,10 +35,10 @@
 in
   stdenv.mkDerivation rec {
     pname = "playdate-sdk";
-    version = "2.7.3";
+    version = "2.7.6";
     src = pkgs.fetchurl {
       url = "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${version}.tar.gz";
-      sha256 = "sha256-Zc9J5np1a88pCHvktK7jUnNCtx/369dXfea2vJf3DWo=";
+      sha256 = "sha256-PjirdoWe4oC73lWusekV4RJTnUHrRxzQPMz3DdQ9e0Y=";
     };
 
     buildInputs = pdcInputs;


### PR DESCRIPTION
- Fix nix run by making the example .pdx file consistent with the CMakeLists.txt file.
- Updated sdk to 2.7.6, example still compiles and runs
- Removed spacing in the run script to allow it to run without error.