### PR TITLE
fix: rename wrapGAppsHook -> wrapGAppsHook3 and xorg.libX11 -> libx11

### DIFF
--- a/playdate-sdk.nix
+++ b/playdate-sdk.nix
@@ -19,7 +19,7 @@
     gdk-pixbuf
     glib
     webkitgtk_4_1
-    xorg.libX11
+    libx11
     stdenv.cc.cc.lib
     libxkbcommon
     wayland
@@ -42,7 +42,7 @@ in
     };
 
     buildInputs = pdcInputs;
-    nativeBuildInputs = [ pkgs.makeWrapper pkgs.wrapGAppsHook ];
+    nativeBuildInputs = [ pkgs.makeWrapper pkgs.wrapGAppsHook3 ];
     dontFixup = true;
 
     installPhase = ''


### PR DESCRIPTION
Recent nixpkgs (post nixos-25.05) made the wrapGAppsHook -> wrapGAppsHook3 rename and the xorg.libX11 -> libx11 rename hard errors. This unbreaks the build when consumers pin nixpkgs to nixos-unstable.